### PR TITLE
Custom loss fn

### DIFF
--- a/brontes/core.py
+++ b/brontes/core.py
@@ -26,7 +26,7 @@ class Brontes(pl.LightningModule):
 
         Args:
             model (torch.nn.Module): a model object.
-            loss (torch.nn.Module): a loss object.
+            loss (callable fn): a loss object.
             data_loaders (dict): a dict of torch.utils.data.DataLoader objects.
                 It has to contain 'train', 'val' and optionally a 'test'.
             optimizers (list of/or torch.optim.Optimizer): optimizer/s adopted.
@@ -89,12 +89,12 @@ class Brontes(pl.LightningModule):
             a dict containing the loss and, optionally, additional metrics.
         """
         x, y = self.batch_fn(batch)
-        y_hat = self.forward(x)
+        out = self.forward(x)
         training_dict = {
-            'loss': self.loss(y_hat, y)
+            'loss': self.loss(out, y)
         }
         for name, metric in self.metrics.items():
-            training_dict[name] = metric(y_hat, y)
+            training_dict[name] = metric(out, y)
         if batch_nb % self.training_log_interval == 0:
             self.tracker.log_tensor_dict(
                 training_dict, step=self.training_step_count

--- a/brontes/examples/__init__.py
+++ b/brontes/examples/__init__.py
@@ -1,2 +1,3 @@
 """Initialize examples module."""
 from .net import Net  # noqa
+from .vae import VAE

--- a/brontes/examples/vae.py
+++ b/brontes/examples/vae.py
@@ -1,0 +1,32 @@
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class VAE(nn.Module):
+    def __init__(self):
+        super(VAE, self).__init__()
+
+        self.fc1 = nn.Linear(784, 400)
+        self.fc21 = nn.Linear(400, 20)
+        self.fc22 = nn.Linear(400, 20)
+        self.fc3 = nn.Linear(20, 400)
+        self.fc4 = nn.Linear(400, 784)
+
+    def encode(self, x):
+        h1 = F.relu(self.fc1(x))
+        return self.fc21(h1), self.fc22(h1)
+
+    def reparameterize(self, mu, logvar):
+        std = torch.exp(0.5*logvar)
+        eps = torch.randn_like(std)
+        return mu + eps*std
+
+    def decode(self, z):
+        h3 = F.relu(self.fc3(z))
+        return torch.sigmoid(self.fc4(h3))
+
+    def forward(self, x):
+        mu, logvar = self.encode(x.view(-1, 784))
+        z = self.reparameterize(mu, logvar)
+        return self.decode(z), mu, logvar

--- a/examples/mnist/run_classification.py
+++ b/examples/mnist/run_classification.py
@@ -16,7 +16,7 @@ from brontes.examples import Net
 from brontes import Brontes
 
 # logging setup
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger('mnist-training')
 
 # # configure argument parser
@@ -43,7 +43,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '-b', '--batch_size', type=int,
-    help='batch size.', default=25,
+    help='batch size.', default=32,
     required=False
 )
 parser.add_argument(
@@ -53,7 +53,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '-l', '--learning_rate', type=float,
-    help='learning rate.', default=1e-5,
+    help='learning rate.', default=10e-3,
     required=False
 )
 

--- a/examples/mnist/run_vae.py
+++ b/examples/mnist/run_vae.py
@@ -1,0 +1,148 @@
+"""Training script with brontes."""
+# imports
+import logging
+import sys
+import argparse
+import tempfile
+import os
+import numpy as np
+
+import torch
+from torch.nn import functional as F
+import torchvision.datasets as datasets
+import torchvision.transforms as transforms
+import pytorch_lightning as pl
+
+from brontes.examples import VAE
+from brontes import Brontes
+
+# logging setup
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logging.getLogger('vae-mnist-training')
+
+# # configure argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-d', '--data_path', type=str,
+    help='path to the data.', default='data/',
+    required=False
+)
+parser.add_argument(
+    '-p', '--number_of_workers', type=int,
+    help='number of workers.', default=1,
+    required=False
+)
+parser.add_argument(
+    '-n', '--model_name', type=str,
+    help='model name.', default='model',
+    required=False
+)
+parser.add_argument(
+    '-s', '--seed', type=int,
+    help='seed for reproducible results.', default=42,
+    required=False
+)
+parser.add_argument(
+    '-b', '--batch_size', type=int,
+    help='batch size.', default=32,
+    required=False
+)
+parser.add_argument(
+    '--epochs', type=int,
+    help='epochs.', default=2,
+    required=False
+)
+parser.add_argument(
+    '-l', '--learning_rate', type=float,
+    help='learning rate.', default=10e-3,
+    required=False
+)
+
+
+def main(args):
+    """
+    Train VAE on MNIST with brontes.
+
+    Args:
+        args (Namespace): parsed args.
+    """
+
+    # make sure the data folder exists
+    os.makedirs(args.data_path, exist_ok=True)
+
+    # set the seed
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    # data loaders for the MNIST dataset
+    def collate_fn(batch):
+        """
+        In a VAE the input and the target are the same.
+        """
+        x = torch.cat([example[0] for example in batch])
+        return x, x
+
+    dataset_loaders = {
+        'train':
+            torch.utils.data.DataLoader(
+                datasets.MNIST(
+                    root=args.data_path,
+                    train=True,
+                    download=True,
+                    transform=transforms.ToTensor()
+                ),
+                batch_size=args.batch_size,
+                shuffle=True,
+                num_workers=args.number_of_workers,
+                collate_fn=collate_fn
+            ),
+        'val':
+            torch.utils.data.DataLoader(
+                datasets.MNIST(
+                    root=args.data_path,
+                    train=False,
+                    download=True,
+                    transform=transforms.ToTensor()
+                ),
+                batch_size=args.batch_size,
+                shuffle=True,
+                num_workers=args.number_of_workers,
+                collate_fn=collate_fn
+            )
+    }
+
+    # definition of base model
+    vae_model = VAE()
+
+    optimizer = torch.optim.Adam(
+        vae_model.parameters(),
+        lr=args.learning_rate,
+        weight_decay=1e-5  # standard value
+    )
+
+    def loss_fn(out, x):
+        recon_x, mu, logvar = out
+        bce = F.binary_cross_entropy(recon_x, x.view(-1, 784))
+        kld = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())
+        return bce + kld
+
+    brontes_model = Brontes(
+        model=vae_model,
+        loss=loss_fn,
+        data_loaders=dataset_loaders,
+        optimizers=optimizer,
+        training_log_interval=10
+    )
+
+    # finally, train the model
+    trainer = pl.Trainer(max_nb_epochs=args.epochs)
+    trainer.fit(brontes_model)
+
+    # save the model
+    saved_model = f'{tempfile.mkdtemp()}/{args.model_name}.pt'
+    torch.save(brontes_model.model, saved_model)
+
+
+if __name__ == "__main__":
+    main(args=parser.parse_args())


### PR DESCRIPTION
Addressing issue #19: 

- Adapt (mostly renaming) `core.py` to handle customized losses (eg losses that require more than logits and ground truth labels). 
- New VAE example where a customized loss is required (cross entropy + kl divergence loss).  
- Minor changes in `run_classification.py` (larger learning rate, `logging.INFO` as default)